### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master  # deploy when pushing to main branch
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/giuseppefrattura/Astro/security/code-scanning/5](https://github.com/giuseppefrattura/Astro/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults. For this workflow, the best minimal fix is:

- `permissions:`
  - `contents: read`

This preserves current behavior (checkout/build/deploy via AWS secrets) while ensuring `GITHUB_TOKEN` is not over-privileged if repo/org defaults are permissive.  
Change file **`.github/workflows/astro.yml`** near the top level, after the `on:` trigger (or before `jobs:`), adding the root-level `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
